### PR TITLE
Update/Fix standard library dependency

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -23,6 +23,7 @@ gleam_erlang = ">= 0.25.0 and < 1.0.0"
 puddle = ">= 0.5.0 and < 1.0.0"
 gleam_otp = ">= 0.10.0 and < 1.0.0"
 tom = ">= 1.0.1 and < 2.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,17 +3,18 @@
 
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "esqlite", version = "0.8.8", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "374902457C7D94DC9409C98D3BDD1CA0D50A60DC9F3BDF1FD8EB74C0DCDF02D6" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
+  { name = "esqlite", version = "0.8.9", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "465AE9AE28AE4192EA54C829FDC90C320447D439A9B2E10946621672FC6A6F8C" },
+  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
+  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
+  { name = "gleam_otp", version = "0.16.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "FA0EB761339749B4E82D63016C6A18C4E6662DA05BAB6F1346F9AF2E679E301A" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
   { name = "puddle", version = "0.5.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "puddle", source = "hex", outer_checksum = "1D199F61CAB692DA84CE8153C9351DC21C68C62BCE75782AFAAD5EE780144806" },
-  { name = "simplifile", version = "2.0.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "95219227A43FCFE62C6E494F413A1D56FF953B68FE420698612E3D89A1EFE029" },
-  { name = "sqlight", version = "0.9.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "2D9C9BA420A5E7DCE7DB2DAAE4CAB0BE6218BEB48FD1531C583550B3D1316E94" },
-  { name = "tom", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "9EECB60150E834A07238BD5C7DF1FF07F7D4C5862BB8A773923D1981C7875FB0" },
+  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
+  { name = "sqlight", version = "0.9.1", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "A495F2892627B2268CCBCC5107EDC1E1AD9547D5F4F21A5DB04CEA72B8931B00" },
+  { name = "tom", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "228E667239504B57AD05EC3C332C930391592F6C974D0EFECF32FFD0F3629A27" },
 ]
 
 [requirements]
@@ -21,6 +22,7 @@ argv = { version = ">= 1.0.2 and < 2.0.0" }
 filepath = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 justin = { version = ">= 1.0.1 and < 2.0.0" }

--- a/src/feather/migrate.gleam
+++ b/src/feather/migrate.gleam
@@ -8,7 +8,7 @@ import gleam/int
 import gleam/io
 import gleam/list
 import gleam/option.{None, Some}
-import gleam/regex
+import gleam/regexp
 import gleam/result
 import gleam/string
 import justin
@@ -33,22 +33,22 @@ const helptext = "
 
 fn get_gleam_toml() -> Result(Dict(String, Toml), Nil) {
   simplifile.read("gleam.toml")
-  |> result.nil_error()
+  |> result.replace_error(Nil)
   |> result.map(tom.parse)
-  |> result.then(result.nil_error)
+  |> result.then(result.replace_error(_, Nil))
 }
 
 fn get_migrations_dir() -> String {
   get_gleam_toml()
   |> result.map(tom.get_string(_, ["migrations_dir"]))
-  |> result.then(result.nil_error)
+  |> result.then(result.replace_error(_, Nil))
   |> result.unwrap("./migrations")
 }
 
 fn get_schema_file() -> String {
   get_gleam_toml()
   |> result.map(tom.get_string(_, ["schemafile"]))
-  |> result.then(result.nil_error)
+  |> result.then(result.replace_error(_, Nil))
   |> result.unwrap("./schema.sql")
 }
 
@@ -353,8 +353,10 @@ fn get_migration_filenames(
 
     use #(numbers, _) <- result.try(string.split_once(filename, "_"))
 
-    use regex <- result.try(regex.from_string("^[0-9]+$") |> result.nil_error)
-    use <- bool.guard(when: !regex.check(regex, numbers), return: Error(Nil))
+    use regex <- result.try(
+      regexp.from_string("^[0-9]+$") |> result.replace_error(Nil),
+    )
+    use <- bool.guard(when: !regexp.check(regex, numbers), return: Error(Nil))
     Ok(path)
   })
   |> result.values

--- a/src/feather/pool.gleam
+++ b/src/feather/pool.gleam
@@ -13,7 +13,9 @@ pub fn start(
   config: feather.Config,
   count: Int,
 ) -> Result(Pool(a), actor.StartError) {
-  puddle.start(count, fn() { feather.connect(config) |> result.nil_error })
+  puddle.start(count, fn() {
+    feather.connect(config) |> result.replace_error(Nil)
+  })
 }
 
 pub fn with_connection(pool: Pool(a), timeout: Int, fxn: fn(Connection) -> a) {
@@ -29,7 +31,8 @@ pub fn with_transaction(
   let result =
     with_connection(pool, timeout, fn(connection) {
       use _ <- result.try(
-        sqlight.exec("BEGIN TRANSACTION;", connection) |> result.nil_error,
+        sqlight.exec("BEGIN TRANSACTION;", connection)
+        |> result.replace_error(Nil),
       )
       case fxn(connection) {
         Ok(val) -> {


### PR DESCRIPTION
Hi,

The Gleam standard library has been updated, and the `gleam/regex` module has been removed.  
If you use Feather as a dependency with the latest standard library, compilation will fail.  

To address this issue, the following changes have been made:

- Updated `gleam_stdlib` to version `0.51.0`.
- Added `gleam_regexp` to replace the removed `gleam/regex` module.
- Replaced deprecated `result.nil_error` with `result.replace_error`.

Thank you very much,  
\- Felix :)
